### PR TITLE
add --exit-error option & detect version

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -50,7 +50,9 @@ export async function main(): Promise<void> {
   const SCAN_MODE = options.scanMode ? options.scanMode : "RAPID"
   const FAIL_ON_ALL = options.failOnAll ? options.failOnAll : false
   const DETECT_TRUST_CERT = options.detectTrustCert ? options.detectTrustCert : false
-  const ERROR_EXIT = options.errorExit ? options.errorExit : false
+  const ERROR_EXIT = Boolean(options.errorExit)
+  const DETECT_VERSION = options.detectVersion ? options.detectVersion : undefined
+  const DEBUG = Boolean(options.debug)
 
   if (SCAN_MODE != "RAPID" && SCAN_MODE != "INTELLIGENT") {
     logger.error(`Scan mode must be RAPID or INTELLIGENT`)
@@ -109,7 +111,7 @@ export async function main(): Promise<void> {
     }
   }
 
-  const detectPath = await findOrDownloadDetect(runnerTemp).catch(reason => {
+  const detectPath = await findOrDownloadDetect(runnerTemp, DEBUG, DETECT_VERSION).catch(reason => {
     logger.error(`Unable to download Detect: ${reason}`)
     process.exit(1)
   })

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,6 +37,7 @@ export async function main(): Promise<void> {
       .option('-m, --scan-mode <RAPID|INTELLIGENT>', 'Black Duck scan mode')
       .option('-f, --fail-on-all', 'Fail on all policy severities')
       .option('-s, --detect-trust-cert', 'Explicitly trust Black Duck Hub SSL Cert')
+      .option('-e, --error-exit', 'Exit with error code on policy violation or Black Duck error')
       .option('-d, --debug', 'Enable debug mode (extra verbosity)')
       .parse(process.argv)
 
@@ -49,6 +50,7 @@ export async function main(): Promise<void> {
   const SCAN_MODE = options.scanMode ? options.scanMode : "RAPID"
   const FAIL_ON_ALL = options.failOnAll ? options.failOnAll : false
   const DETECT_TRUST_CERT = options.detectTrustCert ? options.detectTrustCert : false
+  const ERROR_EXIT = options.errorExit ? options.errorExit : false
 
   if (SCAN_MODE != "RAPID" && SCAN_MODE != "INTELLIGENT") {
     logger.error(`Scan mode must be RAPID or INTELLIGENT`)
@@ -215,8 +217,14 @@ export async function main(): Promise<void> {
 
   if (hasPolicyViolations) {
     logger.warn('Found dependencies violating policy!')
+    if (ERROR_EXIT) {
+      process.exit(1)
+    }
   } else if (detectExitCode > 0) {
     logger.warn('Dependency check failed! See Detect output for more information.')
+    if (ERROR_EXIT) {
+      process.exit(1)
+    }
   } else if (detectExitCode === SUCCESS) {
     logger.info('None of your dependencies violate your Black Duck policies!')
   }


### PR DESCRIPTION
Hello, we're using your code for our CI jobs, and it's working really well. Your work is greatly appreciated. We want to set things up so that if there are any errors during the Blackduck run or if any policy violations occur, the job will intentionally fail. This is to help prevent potential security problems in our repository. So, I'm suggesting a pull request that adds an extra option to decide if the program should stop with an error

Additionally, we have identified an issue where the deleted version is not being passed to the findOrDownloadDetect function. We have addressed this problem